### PR TITLE
Handle authentication error

### DIFF
--- a/league_ranking/get_league_ranking.py
+++ b/league_ranking/get_league_ranking.py
@@ -39,6 +39,9 @@ def _get_splatoon_ranking(match_date_uri):
     r = requests.get(
         SPLATOON2_LEAGUE_MATCH_RANKING_URI.format(match_date_uri),
         cookies=COOKIES)
+    if r.status_code == 403:
+        print("error: authentication Error. make sure your iksm_session.")
+        sys.exit(1)
     return r.text
 
 

--- a/league_ranking/get_league_ranking.py
+++ b/league_ranking/get_league_ranking.py
@@ -33,13 +33,14 @@ FIRST_TIME_OF_LEAGUE_MATCH = datetime(
 
 MIN_SLEEP_SEC = 2
 MAX_SLEEP_SEC = 5
+AUTHENTICATION_ERROR='AUTHENTICATION_ERROR'
 
 
 def _get_splatoon_ranking(match_date_uri):
     r = requests.get(
         SPLATOON2_LEAGUE_MATCH_RANKING_URI.format(match_date_uri),
         cookies=COOKIES)
-    if r.status_code == 403:
+    if r.status_code == 403 and r.json().get('code') == AUTHENTICATION_ERROR:
         print("error: authentication Error. make sure your iksm_session.")
         sys.exit(1)
     return r.text

--- a/league_ranking/get_league_ranking.py
+++ b/league_ranking/get_league_ranking.py
@@ -41,7 +41,7 @@ def _get_splatoon_ranking(match_date_uri):
         SPLATOON2_LEAGUE_MATCH_RANKING_URI.format(match_date_uri),
         cookies=COOKIES)
     if r.status_code == 403 and r.json().get('code') == AUTHENTICATION_ERROR:
-        print("error: authentication Error. make sure your iksm_session.")
+        print("error: authentication error. make sure your iksm_session.")
         sys.exit(1)
     return r.text
 


### PR DESCRIPTION
iksm_sessionの値が間違っている場合に、`/app.splatoon2.nintendo.net/api`側からステータスコードの値が403、code=AUTHENTICATION_ERRORの内容のレスポンスが返ってきています。
現状何らかの既存ファイルがない場合は、処理のエラー内容がわからないため、認証失敗の旨を出力し、実行を中止させています。

下記は認証失敗時にファイルに出力される内容です。
```
{"code":"AUTHENTICATION_ERROR","message":"api_error_authentication_error"}
```